### PR TITLE
fix: fix a bug where the input text was determined unintentionally

### DIFF
--- a/lib/src/chat_input_toolbar.dart
+++ b/lib/src/chat_input_toolbar.dart
@@ -93,12 +93,12 @@ class ChatInputToolbar extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
                   child: Directionality(
                     textDirection: textDirection,
-                    child: TextField(
+                    child: TextFormField(
                       focusNode: focusNode,
                       onChanged: (value) {
                         onTextChange!(value);
                       },
-                      onSubmitted: (value) {
+                      onSaved: (value) {
                         if (sendOnEnter) {
                           _sendMessage(context, message);
                         }


### PR DESCRIPTION
Hey, guys.

I noticed some inconvenient behavior in FlutterFlow's standard chat. The behavior is that when users enter multibyte characters, they are unable to enter the characters as intended. Even if I try to input "テスト (=Japanese word that means test in English)", it will be converted to "tエスト" or "tスト". Please watch the following video for details.

https://github.com/FlutterFlow/flutterflow_dash_chat/assets/2719533/09dd4c16-0c50-4ddc-a3e7-a84d6345d4a0

This is a video of the app screen that was built from the downloaded code using an HTML renderer for the web.
Similar behavior can be observed when checking in TestMode.

https://github.com/FlutterFlow/flutterflow_dash_chat/assets/2719533/eb91b1e3-da1f-4562-9234-619a11e8523e

By making the changes in this pull request, users will be able to enter the characters they intended, as shown in the video below.

https://github.com/FlutterFlow/flutterflow_dash_chat/assets/2719533/4752e95f-7826-4143-88ca-6876dd618e68

Please review this pull request and merge it if there are no problems.
